### PR TITLE
fix: synchronize fullscreen wallpaper with selected novel

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -14,6 +14,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { HeroSection } from "@/components/HeroSection";
 import { useModeStore } from "@/store/modeStore";
 import { ChapterSidebar } from "@/components/ChapterSidebar";
+import { useNovelBackground } from "@/hooks/useNovelBackground";
 
 type Novel = "noli" | "fili";
 type Tab = "chapters" | "characters" | "themes";
@@ -95,11 +96,13 @@ export default function Home() {
     handleChapterSelect(book, chapter);
   };
 
+  const backgroundStyle = useNovelBackground(novel);
+
   return (
     <main
-      className={`min-h-screen pb-20 transition-colors duration-700 ease-in-out ${novel === 'fili' ? 'bg-[#F2F0ED]' : 'bg-brand-cream' // Slightly darker stone/warm grey for Fili
-        }`}
+      className={`min-h-screen pb-20 transition-colors duration-700 ease-in-out`}
       data-novel={novel}
+      style={backgroundStyle}
     >
       {/* Header Section */}
       <header

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -11,6 +11,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { ArrowLeft, BarChart2 } from "lucide-react";
 import { Suspense } from "react";
 import { useModeStore } from "@/store/modeStore";
+import { useNovelBackground } from "@/hooks/useNovelBackground";
 
 interface ChapterContent {
     sentence_index: number;
@@ -95,8 +96,13 @@ function SearchContent() {
     const col1 = singleNovelResults.slice(0, midpoint);
     const col2 = singleNovelResults.slice(midpoint);
 
+    const backgroundStyle = useNovelBackground(novelFilter);
+
     return (
-        <div className="min-h-screen bg-brand-cream flex flex-col">
+        <div
+            className="min-h-screen flex flex-col"
+            style={backgroundStyle}
+        >
             {/* Sticky Header */}
             <header className="bg-brand-cream/98 border-b border-brand-gold/20 sticky top-0 z-40 backdrop-blur-sm">
                 <div className="max-w-6xl mx-auto px-4 py-3 flex items-center gap-4">

--- a/frontend/components/ChapterModal.tsx
+++ b/frontend/components/ChapterModal.tsx
@@ -6,6 +6,7 @@ import { X, Maximize2, Minimize2, ChevronLeft, ChevronRight, Users, BookOpen } f
 import { CHARACTERS, Character } from "@/lib/characterData";
 import { ItemModal } from "@/components/ItemModal";
 import { useModeStore } from "@/store/modeStore";
+import { useNovelBackground } from "@/hooks/useNovelBackground";
 
 interface ThemeMatch {
     id: string;
@@ -89,6 +90,8 @@ export function ChapterModal({
     // State for tracking active chapter in fullscreen
     const [activeChapterInView, setActiveChapterInView] = useState<number>(chapterNumber);
     const initialFullscreenRef = useRef(false);
+
+    const backgroundStyle = useNovelBackground(book);
 
     // Sync active chapter with prop when NOT in fullscreen (background sync)
     useEffect(() => {
@@ -559,7 +562,8 @@ export function ChapterModal({
                             animate={{ opacity: 1, scale: 1, y: 0 }}
                             exit={{ opacity: 0, scale: 0.95, y: 20 }}
                             transition={{ type: "spring", damping: 25, stiffness: 300 }}
-                            className={`relative ${isFullscreen ? 'w-full h-full bg-[#FAFAFA]' : 'w-full max-w-4xl max-h-[90vh] bg-brand-paper rounded-lg'} flex flex-col shadow-2xl overflow-hidden`}
+                            className={`relative ${isFullscreen ? 'w-full h-full' : 'w-full max-w-4xl max-h-[90vh] bg-brand-paper rounded-lg'} flex flex-col shadow-2xl overflow-hidden`}
+                            style={isFullscreen ? backgroundStyle : undefined}
                         >
                             {/* Standard Header (Non-Fullscreen) */}
                             {!isFullscreen && (
@@ -680,7 +684,7 @@ export function ChapterModal({
                                 )}
 
                                 {/* Main Content Scroll Area */}
-                                <div ref={scrollAreaRef} className={`flex-1 overflow-y-auto scrollbar-thin scrollbar-thumb-brand-gold/30 scrollbar-track-transparent bg-brand-paper relative ${isFullscreen ? '' : 'p-6 md:p-14'}`}>
+                                <div ref={scrollAreaRef} className={`flex-1 overflow-y-auto scrollbar-thin scrollbar-thumb-brand-gold/30 scrollbar-track-transparent relative ${isFullscreen ? 'bg-transparent' : 'bg-brand-paper p-6 md:p-14'}`}>
                                     {/* Mobile/Tablet Fullscreen Header Overlay (since sidebar hidden) */}
                                     {isFullscreen && (
                                         <div className="lg:hidden sticky top-0 z-30 bg-brand-paper/95 backdrop-blur border-b border-brand-gold/10 p-4 flex justify-between items-center">

--- a/frontend/hooks/useNovelBackground.ts
+++ b/frontend/hooks/useNovelBackground.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+
+/**
+ * Hook to get the background image and overlay style for a specific novel.
+ * @param novel - 'noli' or 'fili' (or 'both'/null for fallback)
+ * @returns React.CSSProperties object with the background styling
+ */
+export function useNovelBackground(novel: 'noli' | 'fili' | 'both' | string | null | undefined) {
+    return useMemo(() => {
+        const isFili = novel === 'fili' || novel === 'elfili' || novel === 'El Filibusterismo';
+        const bgImage = isFili ? 'elfili_background.jpg' : 'noli_background.jpg';
+
+        // Using the same semi-transparent overlay to ensure text contrast:
+        // Fili: rgba(242, 240, 237, opacity)
+        // Noli: rgba(245, 241, 233, opacity)
+        const overlayColor = isFili ? '242, 240, 237' : '245, 241, 233';
+
+        return {
+            backgroundImage: `linear-gradient(to bottom, rgba(${overlayColor}, 0.85), rgba(${overlayColor}, 0.98)), url('/images/backgrounds/${bgImage}')`,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            backgroundAttachment: 'fixed',
+        };
+    }, [novel]);
+}


### PR DESCRIPTION
Resolved an issue where opening a chapter from search results caused fullscreen mode to display the Noli wallpaper even when El Fili was selected. Fullscreen now reads the global novel state to determine the correct background image.